### PR TITLE
add unequip, fix team2

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -128,11 +128,11 @@ export function writeDuelOptions(
   // }
   // OCG_Player team2 {
   //    uint32_t startingLP
-  view.setUint32(52, options.team1.startingLP, true);
+  view.setUint32(52, options.team2.startingLP, true);
   //    uint32_t startingDrawCount
-  view.setUint32(56, options.team1.startingDrawCount, true);
+  view.setUint32(56, options.team2.startingDrawCount, true);
   //    uint32_t drawCountPerTurn
-  view.setUint32(60, options.team1.drawCountPerTurn, true);
+  view.setUint32(60, options.team2.drawCountPerTurn, true);
   // }
 
   if (options.ptrSize === 4) {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -45,6 +45,19 @@ export function isInfoLocationEmpty(loc: OcgLocPos) {
   );
 }
 
+const INFO_LOCATION_BYTE_LENGTH = 10;
+
+function readTrailingInfoLocations(reader: BufferReader): OcgLocPos[] {
+  if (!reader.avail || reader.avail % INFO_LOCATION_BYTE_LENGTH !== 0) {
+    return [];
+  }
+
+  return Array.from(
+    { length: reader.avail / INFO_LOCATION_BYTE_LENGTH },
+    () => parseInfoLocation(reader),
+  );
+}
+
 export function readMessage(reader: BufferReader): OcgMessage | null {
   const type: OcgMessageType = reader.u8();
   switch (type) {
@@ -561,6 +574,11 @@ export function readMessage(reader: BufferReader): OcgMessage | null {
         player: reader.u8(),
         lp: reader.u32(),
       };
+    case OcgMessageType.UNEQUIP:
+      return {
+        type,
+        card: parseInfoLocation(reader),
+      };
     case OcgMessageType.CARD_TARGET:
       return {
         type,
@@ -644,17 +662,42 @@ export function readMessage(reader: BufferReader): OcgMessage | null {
         code: reader.u32(),
       };
     case OcgMessageType.BE_CHAIN_TARGET:
-      return {
-        type,
-      };
+      return (() => {
+        // Older cores send this as an empty packet. Keep supporting that shape,
+        // but accept trailing info-location payloads when a core build includes
+        // them so the browser bridge can forward real coordinates.
+        const cards = readTrailingInfoLocations(reader);
+        return cards.length ? { type, cards } : { type };
+      })();
     case OcgMessageType.CREATE_RELATION:
-      return {
-        type,
-      };
     case OcgMessageType.RELEASE_RELATION:
-      return {
-        type,
-      };
+      return (() => {
+        // The local core build currently appears to emit this without explicit
+        // relation endpoints, but accept optional trailing locations so newer
+        // protocol variants can expose source/target coordinates.
+        const cards = readTrailingInfoLocations(reader);
+
+        if (cards.length >= 2) {
+          return {
+            type,
+            source: cards[0],
+            target: cards[1],
+            cards,
+          };
+        }
+
+        if (cards.length === 1) {
+          return {
+            type,
+            source: cards[0],
+            cards,
+          };
+        }
+
+        return {
+          type,
+        };
+      })();
     case OcgMessageType.TOSS_COIN:
       return {
         type,

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -65,6 +65,15 @@ export function readQuery(reader: BufferReader) {
         result.equipCard = card;
       }
     } else if (flag === OcgQueryFlags.TARGET_CARD && size >= 4) {
+      result.targetCards = [];
+      const length = reader.u32();
+      for (let i = 0; i < length; i++) {
+        const card = parseInfoLocation(reader);
+        if (!isInfoLocationEmpty(card)) {
+          result.targetCards.push(card);
+        }
+      }
+    } else if (flag === OcgQueryFlags.OVERLAY_CARD && size >= 4) {
       result.overlayCards = [];
       const length = reader.u32();
       for (let i = 0; i < length; i++) {

--- a/src/type_message.ts
+++ b/src/type_message.ts
@@ -97,6 +97,7 @@ export enum OcgMessageType {
   RECOVER = 92,
   EQUIP = 93,
   LPUPDATE = 94,
+  UNEQUIP = 95,
   CARD_TARGET = 96,
   CANCEL_TARGET = 97,
   PAY_LPCOST = 100,
@@ -671,6 +672,11 @@ export interface OcgMessageLPUpdate {
   lp: number;
 }
 
+export interface OcgMessageUnequip {
+  type: OcgMessageType.UNEQUIP;
+  card: OcgLocPos;
+}
+
 export interface OcgMessageCardTarget {
   type: OcgMessageType.CARD_TARGET;
   card: OcgLocPos;
@@ -743,14 +749,21 @@ export interface OcgMessageMissedEffect {
 
 export interface OcgMessageBeChainTarget {
   type: OcgMessageType.BE_CHAIN_TARGET;
+  cards?: OcgLocPos[];
 }
 
 export interface OcgMessageCreateRelation {
   type: OcgMessageType.CREATE_RELATION;
+  source?: OcgLocPos;
+  target?: OcgLocPos;
+  cards?: OcgLocPos[];
 }
 
 export interface OcgMessageReleaseRelation {
   type: OcgMessageType.RELEASE_RELATION;
+  source?: OcgLocPos;
+  target?: OcgLocPos;
+  cards?: OcgLocPos[];
 }
 
 export interface OcgMessageTossCoin {
@@ -960,6 +973,7 @@ export type OcgMessage =
   | OcgMessageRecover
   | OcgMessageEquip
   | OcgMessageLPUpdate
+  | OcgMessageUnequip
   | OcgMessageCardTarget
   | OcgMessageCancelTarget
   | OcgMessagePayLPCost

--- a/src/type_serialize.ts
+++ b/src/type_serialize.ts
@@ -125,6 +125,7 @@ export const ocgMessageTypeStrings = makeMap([
   [OcgMessageType.RECOVER, "recover"],
   [OcgMessageType.EQUIP, "equip"],
   [OcgMessageType.LPUPDATE, "lpupdate"],
+  [OcgMessageType.UNEQUIP, "unequip"],
   [OcgMessageType.CARD_TARGET, "card_target"],
   [OcgMessageType.CANCEL_TARGET, "cancel_target"],
   [OcgMessageType.PAY_LPCOST, "pay_lpcost"],


### PR DESCRIPTION
- `OcgMessageType.UNEQUIP` was missing from the API.
- `team2` was mislabeled on the starting configuration
- `OcgMessageType.CREATE_RELATION`, `OcgMessageType.RELEASE_RELATION`, `OcgMessageType.BE_CHAIN_TARGET`,  returned empty information.

Overall I can confirm this codebase works, and it works well!